### PR TITLE
Use true division on Python 2 to match Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@
 4.2.0 (unreleased)
 ==================
 
+- Use true division on Python 2 to match Python 3, in case certain
+  parameters turn out to be integers instead of floating point values.
+  This is not expected to be user-visible, but it can arise in
+  artificial tests of internal functions.
+
 - Add support for Python 3.5 and 3.6.
 
 - Drop support for Python 2.6, 3.2 and 3.3.

--- a/src/zope/datetime/__init__.py
+++ b/src/zope/datetime/__init__.py
@@ -15,6 +15,8 @@
 
 Encapsulation of date/time values
 """
+from __future__ import division # We do lots of math, make sure it's consistent
+
 import math
 import re
 # there is a method definition that makes just "time"

--- a/src/zope/datetime/tests/test_datetime.py
+++ b/src/zope/datetime/tests/test_datetime.py
@@ -28,7 +28,6 @@ class TestCache(unittest.TestCase):
 class TestFuncs(unittest.TestCase):
 
     def test_correctYear(self):
-
         self.assertEqual(2069, datetime._correctYear(69))
         self.assertEqual(1998, datetime._correctYear(98))
 
@@ -69,10 +68,9 @@ class TestFuncs(unittest.TestCase):
         self.assertEqual(datetime._julianday(0, 1, 1), 1721057)
 
     def test_calendarday(self):
-        # XXX: Why do we get different things on Py2 vs Py3?
-        # Are the calculations wrapping around somewhere? Is it the integer
-        # division?
-        answer = (-4712, 1, 3) if str is bytes else (-4711, 2, 0)
+        # If we don't have the future import of division, we get
+        # different results on Py2/Py3 when we pass an integer.
+        answer = (-4711, 2, 0)
         self.assertEqual(datetime._calendarday(1), answer)
 
     def test_findLocalTimeZoneName(self):


### PR DESCRIPTION
In case certain parameters turn out to be integers instead of floating point values. This is not expected to be user-visible, but it can arise in artificial tests of internal functions.

Refs #4. (Maybe the resolution of #4 will be that this fallback path isn't needed any longer and we can delete it, including this test. But I think true division is still a nice-to-have anyway.)