### PR TITLE
Prevent DeprecationWarning in Python 3.8+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,9 @@
 
 - Add support for Python 3.7, 3.8 and 3.9.
 
-- Prevent DeprecationWarning in Python 3.8+ when using a non-int parameter for
-  ``iso8601_date``, ``rfc850_date``, and ``rfc1123_date``.
+- Prevent a ``DeprecationWarning`` in Python 3.8+ when using a parameter for
+  ``iso8601_date``, ``rfc850_date``, or ``rfc1123_date`` which has to be
+  converted via its ``__int__`` method.
 
 
 4.2.0 (2017-08-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Add support for Python 3.7, 3.8 and 3.9.
 
+- Prevent DeprecationWarning in Python 3.8+ when using a non-int parameter for
+  ``iso8601_date``, ``rfc850_date``, and ``rfc1123_date``.
+
 
 4.2.0 (2017-08-14)
 ==================

--- a/src/zope/datetime/__init__.py
+++ b/src/zope/datetime/__init__.py
@@ -53,6 +53,19 @@ monthname = [
 ]
 
 
+def _get_gmtime_compatible_timestamp(ts):
+    """Try to convert any argument to a timestamp ``time.gmtime`` can use."""
+    if ts is None:
+        # ``time.gmtime`` uses the current time but only if not given any
+        # parameter. It is easier to compute current time here:
+        ts = _time.time()
+    else:
+        # ``time.gmtime`` ignores fractions of seconds. Before Python 3.10 it
+        # used to convert its argument to an ``int`` if it was not a number.
+        ts = int(ts)
+    return ts
+
+
 def iso8601_date(ts=None):
     """
     Return an ISO 8601 formatted date string, required
@@ -60,15 +73,13 @@ def iso8601_date(ts=None):
 
     For example: '2000-11-10T16:21:09-08:00'
 
-    :param int ts: A timestamp as returned by :func:`time.time`.
+    :param any ts: A timestamp as returned by :func:`time.time` (``float``),
+        seconds since the epoch (``int``) or any object which can be converted
+        to ``int`` via a ``__int__`` method returning number of seconds since
+        the epoch.
         If not given, the current time will be used.
-        If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
-        converted to one to prevent a DeprecationWarning in Python 3.8+.
     """
-    if ts is None:
-        ts = _time.time()
-    else:
-        ts = int(ts)
+    ts = _get_gmtime_compatible_timestamp(ts)
     return _time.strftime('%Y-%m-%dT%H:%M:%SZ', _time.gmtime(ts))
 
 
@@ -78,15 +89,12 @@ def rfc850_date(ts=None):
 
     For example, 'Friday, 10-Nov-00 16:21:09 GMT'.
 
-    :param int ts: A timestamp as returned by :func:`time.time`.
-        If not given, the current time will be used.
-        If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
-        converted to one to prevent a DeprecationWarning in Python 3.8+.
+    :param any ts: A timestamp as returned by :func:`time.time` (``float``),
+        seconds since the epoch (``int``) or any object which can be converted
+        to ``int`` via a ``__int__`` method returning number of seconds since
+        the epoch.
     """
-    if ts is None:
-        ts = _time.time()
-    else:
-        ts = int(ts)
+    ts = _get_gmtime_compatible_timestamp(ts)
     year, month, day, hh, mm, ss, wd, _y, _z = _time.gmtime(ts)
     return "%s, %02d-%3s-%2s %02d:%02d:%02d GMT" % (
         weekday_full[wd],
@@ -103,15 +111,12 @@ def rfc1123_date(ts=None):
 
     For example, 'Fri, 10 Nov 2000 16:21:09 GMT'.
 
-    :param int ts: A timestamp as returned by :func:`time.time`.
-        If not given, the current time will be used.
-        If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
-        converted to one to prevent a DeprecationWarning in Python 3.8+.
+    :param any ts: A timestamp as returned by :func:`time.time` (``float``),
+        seconds since the epoch (``int``) or any object which can be converted
+        to ``int`` via a ``__int__`` method returning number of seconds since
+        the epoch.
     """
-    if ts is None:
-        ts = _time.time()
-    else:
-        ts = int(ts)
+    ts = _get_gmtime_compatible_timestamp(ts)
     year, month, day, hh, mm, ss, wd, _y, _z = _time.gmtime(ts)
     return "%s, %02d %3s %4d %02d:%02d:%02d GMT" % (
         weekday_abbr[wd],

--- a/src/zope/datetime/__init__.py
+++ b/src/zope/datetime/__init__.py
@@ -105,9 +105,8 @@ def rfc1123_date(ts=None):
 
     :param int ts: A timestamp as returned by :func:`time.time`.
         If not given, the current time will be used.
-    If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
-    converted to one to prevent a DeprecationWarning in Python 3.8+.
-
+        If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
+        converted to one to prevent a DeprecationWarning in Python 3.8+.
     """
     if ts is None:
         ts = _time.time()

--- a/src/zope/datetime/__init__.py
+++ b/src/zope/datetime/__init__.py
@@ -60,10 +60,15 @@ def iso8601_date(ts=None):
 
     For example: '2000-11-10T16:21:09-08:00'
 
-    :param float ts: A timestamp as returned by :func:`time.time`.
+    :param int ts: A timestamp as returned by :func:`time.time`.
         If not given, the current time will be used.
+        If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
+        converted to one to prevent a DeprecationWarning in Python 3.8+.
     """
-    ts = _time.time() if ts is None else ts
+    if ts is None:
+        ts = _time.time()
+    else:
+        ts = int(ts)
     return _time.strftime('%Y-%m-%dT%H:%M:%SZ', _time.gmtime(ts))
 
 
@@ -73,10 +78,15 @@ def rfc850_date(ts=None):
 
     For example, 'Friday, 10-Nov-00 16:21:09 GMT'.
 
-    :param float ts: A timestamp as returned by :func:`time.time`.
+    :param int ts: A timestamp as returned by :func:`time.time`.
         If not given, the current time will be used.
+        If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
+        converted to one to prevent a DeprecationWarning in Python 3.8+.
     """
-    ts = _time.time() if ts is None else ts
+    if ts is None:
+        ts = _time.time()
+    else:
+        ts = int(ts)
     year, month, day, hh, mm, ss, wd, _y, _z = _time.gmtime(ts)
     return "%s, %02d-%3s-%2s %02d:%02d:%02d GMT" % (
         weekday_full[wd],
@@ -93,11 +103,16 @@ def rfc1123_date(ts=None):
 
     For example, 'Fri, 10 Nov 2000 16:21:09 GMT'.
 
-    :param float ts: A timestamp as returned by :func:`time.time`.
+    :param int ts: A timestamp as returned by :func:`time.time`.
         If not given, the current time will be used.
-    """
+    If ``param`` is not an ``int`` (e. g. a DateTime object) it gets
+    converted to one to prevent a DeprecationWarning in Python 3.8+.
 
-    ts = _time.time() if ts is None else ts
+    """
+    if ts is None:
+        ts = _time.time()
+    else:
+        ts = int(ts)
     year, month, day, hh, mm, ss, wd, _y, _z = _time.gmtime(ts)
     return "%s, %02d %3s %4d %02d:%02d:%02d GMT" % (
         weekday_abbr[wd],

--- a/src/zope/datetime/tests/test_standard_dates.py
+++ b/src/zope/datetime/tests/test_standard_dates.py
@@ -13,9 +13,19 @@
 ##############################################################################
 """Tests standard date parsing
 """
+import datetime
 import unittest
 
 from zope.datetime import time
+
+
+class FakeDateTime:
+    """A class which mimics a DateTime class which can be converted to int."""
+
+    time = time("2000-01-01T01:01:01.234Z")
+
+    def __int__(self):
+        return int(self.time)
 
 
 class Test(unittest.TestCase):
@@ -25,20 +35,51 @@ class Test(unittest.TestCase):
         self.assertEqual(iso8601_date(time("2000-01-01T01:01:01.234Z")),
                          "2000-01-01T01:01:01Z")
 
+    def testiso8601_date__2(self):
+        """It converts its parameter to an int."""
+        from zope.datetime import iso8601_date
+        self.assertEqual(iso8601_date(FakeDateTime()), "2000-01-01T01:01:01Z")
+
+    def testiso8601_date__3(self):
+        """It uses the current time if no parameter is given."""
+        from zope.datetime import iso8601_date
+        self.assertTrue(
+            iso8601_date().startswith(str(datetime.date.today())))
+
     def testrfc850_date(self):
         from zope.datetime import rfc850_date
         self.assertEqual(rfc850_date(time("2002-01-12T01:01:01.234Z")),
                          "Saturday, 12-Jan-02 01:01:01 GMT")
+
+    def testrfc850_date__2(self):
+        """It converts its parameter to an int."""
+        from zope.datetime import rfc850_date
+        self.assertEqual(rfc850_date(FakeDateTime()),
+                         "Saturday, 01-Jan-00 01:01:01 GMT")
+
+    def testrfc850_date__3(self):
+        """It uses the current time if no parameter is given."""
+        from zope.datetime import rfc850_date
+        self.assertIn(datetime.date.today().strftime('%d-%b-%y'),
+                      rfc850_date())
 
     def testrfc1123_date(self):
         from zope.datetime import rfc1123_date
         self.assertEqual(rfc1123_date(time("2002-01-12T01:01:01.234Z")),
                          "Sat, 12 Jan 2002 01:01:01 GMT")
 
+    def testrfc1123_date__2(self):
+        """It converts its parameter to an int."""
+        from zope.datetime import rfc1123_date
+        self.assertEqual(rfc1123_date(FakeDateTime()),
+                         "Sat, 01 Jan 2000 01:01:01 GMT")
+
+    def testrfc1123_date__3(self):
+        """It uses the current time if no parameter is given."""
+        from zope.datetime import rfc1123_date
+        self.assertIn(datetime.date.today().strftime('%d %b %Y'),
+                      rfc1123_date())
+
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/zope/datetime/tests/test_standard_dates.py
+++ b/src/zope/datetime/tests/test_standard_dates.py
@@ -20,7 +20,10 @@ from zope.datetime import time
 
 
 class FakeDateTime:
-    """A class which mimics a DateTime class which can be converted to int."""
+    """A class which mimics a DateTime class which can be converted to int.
+
+    It behaves like the Zope DateTime class in the DateTime package.
+    """
 
     time = time("2000-01-01T01:01:01.234Z")
 


### PR DESCRIPTION
It occurred when using a non-int parameter for `iso8601_date`, `rfc850_date`, and `rfc1123_date`.